### PR TITLE
Changing data storage from gdrive to gcp bucket

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,7 @@
 [core]
-    remote = myremote
+    remote = remote_storage
 ['remote "myremote"']
     url = gdrive://13ViBpZs9d8ySn_hOSdM7Zhp6_GKd9pKL
+['remote "remote_storage"']
+    url = gs://mlops_g22_databucket/
+    version_aware = true


### PR DESCRIPTION
Changes in the .dvc/config file to link the repo to a GCP Bucket for data storage rather than G-Drive. Please check that you guys can still pull the data with no authentication issues, or other errors!